### PR TITLE
Let feeds get a custom_order

### DIFF
--- a/src/parser/feed.go
+++ b/src/parser/feed.go
@@ -86,6 +86,9 @@ func ParseWithEncoding(r io.Reader, fallbackEncoding string) (*Feed, error) {
 		r = io.MultiReader(bytes.NewReader(lookup), r)
 	}
 
+	// out.callback() will return the parsed feed. there's no custom order here,
+	// that's only applicable in the storage part, and in the opml-import part.
+	// this is a third "feed" representation.
 	out := sniff(string(lookup))
 	if out.feedType == "" {
 		return nil, UnknownFormat

--- a/src/server/opml/opml.go
+++ b/src/server/opml/opml.go
@@ -13,9 +13,10 @@ type Folder struct {
 }
 
 type Feed struct {
-	Title   string
-	FeedUrl string
-	SiteUrl string
+	Title       string
+	FeedUrl     string
+	SiteUrl     string
+	CustomOrder string
 }
 
 func (f Folder) AllFeeds() []Feed {
@@ -52,8 +53,8 @@ func (f Folder) outline(level int) string {
 
 func (f Feed) outline(level int) string {
 	return strings.Repeat(indent, level) + fmt.Sprintf(
-		`<outline type="rss" text="%s" xmlUrl="%s" htmlUrl="%s"/>`+nl,
-		e(f.Title), e(f.FeedUrl), e(f.SiteUrl),
+		`<outline type="rss" text="%s" xmlUrl="%s" htmlUrl="%s" customOrder="%s"/>`+nl,
+		e(f.Title), e(f.FeedUrl), e(f.SiteUrl), e(f.CustomOrder),
 	)
 }
 

--- a/src/server/opml/opml_test.go
+++ b/src/server/opml/opml_test.go
@@ -10,9 +10,10 @@ func TestOPML(t *testing.T) {
 		Title: "",
 		Feeds: []Feed{
 			{
-				Title:   "title1",
-				FeedUrl: "https://baz.com/feed.xml",
-				SiteUrl: "https://baz.com/",
+				Title:       "title1",
+				FeedUrl:     "https://baz.com/feed.xml",
+				SiteUrl:     "https://baz.com/",
+				CustomOrder: "",
 			},
 		},
 		Folders: []Folder{
@@ -20,14 +21,16 @@ func TestOPML(t *testing.T) {
 				Title: "sub",
 				Feeds: []Feed{
 					{
-						Title:   "subtitle1",
-						FeedUrl: "https://foo.com/feed.xml",
-						SiteUrl: "https://foo.com/",
+						Title:       "subtitle1",
+						FeedUrl:     "https://foo.com/feed.xml",
+						SiteUrl:     "https://foo.com/",
+						CustomOrder: "123",
 					},
 					{
-						Title:   "&>",
-						FeedUrl: "https://bar.com/feed.xml",
-						SiteUrl: "https://bar.com/",
+						Title:       "&>",
+						FeedUrl:     "https://bar.com/feed.xml",
+						SiteUrl:     "https://bar.com/",
+						CustomOrder: "456",
 					},
 				},
 				Folders: []Folder{},
@@ -39,10 +42,10 @@ func TestOPML(t *testing.T) {
 <head><title>subscriptions</title></head>
 <body>
   <outline text="sub">
-    <outline type="rss" text="subtitle1" xmlUrl="https://foo.com/feed.xml" htmlUrl="https://foo.com/"/>
-    <outline type="rss" text="&amp;&gt;" xmlUrl="https://bar.com/feed.xml" htmlUrl="https://bar.com/"/>
+    <outline type="rss" text="subtitle1" xmlUrl="https://foo.com/feed.xml" htmlUrl="https://foo.com/" customOrder="123"/>
+    <outline type="rss" text="&amp;&gt;" xmlUrl="https://bar.com/feed.xml" htmlUrl="https://bar.com/" customOrder="456"/>
   </outline>
-  <outline type="rss" text="title1" xmlUrl="https://baz.com/feed.xml" htmlUrl="https://baz.com/"/>
+  <outline type="rss" text="title1" xmlUrl="https://baz.com/feed.xml" htmlUrl="https://baz.com/" customOrder=""/>
 </body>
 </opml>
 `

--- a/src/server/opml/read.go
+++ b/src/server/opml/read.go
@@ -13,12 +13,13 @@ type opml struct {
 }
 
 type outline struct {
-	Type     string    `xml:"type,attr,omitempty"`
-	Title    string    `xml:"text,attr"`
-	Title2   string    `xml:"title,attr,omitempty"`
-	FeedUrl  string    `xml:"xmlUrl,attr,omitempty"`
-	SiteUrl  string    `xml:"htmlUrl,attr,omitempty"`
-	Outlines []outline `xml:"outline,omitempty"`
+	Type        string    `xml:"type,attr,omitempty"`
+	Title       string    `xml:"text,attr"`
+	Title2      string    `xml:"title,attr,omitempty"`
+	FeedUrl     string    `xml:"xmlUrl,attr,omitempty"`
+	SiteUrl     string    `xml:"htmlUrl,attr,omitempty"`
+	CustomOrder string    `xml:"customOrder,attr,omitempty"`
+	Outlines    []outline `xml:"outline,omitempty"`
 }
 
 func buildFolder(title string, outlines []outline) Folder {
@@ -26,9 +27,10 @@ func buildFolder(title string, outlines []outline) Folder {
 	for _, outline := range outlines {
 		if outline.Type == "rss" || outline.FeedUrl != "" {
 			folder.Feeds = append(folder.Feeds, Feed{
-				Title:   outline.Title,
-				FeedUrl: outline.FeedUrl,
-				SiteUrl: outline.SiteUrl,
+				Title:       outline.Title,
+				FeedUrl:     outline.FeedUrl,
+				SiteUrl:     outline.SiteUrl,
+				CustomOrder: outline.CustomOrder,
 			})
 		} else {
 			title := outline.Title

--- a/src/server/routes.go
+++ b/src/server/routes.go
@@ -35,7 +35,7 @@ func (s *Server) handler() http.Handler {
 			Username: s.Username,
 			Password: s.Password,
 			Public:   []string{"/static", "/fever"},
-            DB:       s.db,
+			DB:       s.db,
 		}
 		r.Use(a.Handler)
 	}
@@ -243,6 +243,7 @@ func (s *Server) handleFeedList(c *router.Context) {
 				"",
 				result.Feed.SiteURL,
 				result.FeedLink,
+				"",
 				form.FolderID,
 			)
 			items := worker.ConvertItems(result.Feed.Items, *feed)
@@ -431,12 +432,12 @@ func (s *Server) handleOPMLImport(c *router.Context) {
 			return
 		}
 		for _, f := range doc.Feeds {
-			s.db.CreateFeed(f.Title, "", f.SiteUrl, f.FeedUrl, nil)
+			s.db.CreateFeed(f.Title, "", f.SiteUrl, f.FeedUrl, f.CustomOrder, nil)
 		}
 		for _, f := range doc.Folders {
 			folder := s.db.CreateFolder(f.Title)
 			for _, ff := range f.AllFeeds() {
-				s.db.CreateFeed(ff.Title, "", ff.SiteUrl, ff.FeedUrl, &folder.Id)
+				s.db.CreateFeed(ff.Title, "", ff.SiteUrl, ff.FeedUrl, ff.CustomOrder, &folder.Id)
 			}
 		}
 
@@ -461,9 +462,10 @@ func (s *Server) handleOPMLExport(c *router.Context) {
 			feed := feed
 			if feed.FolderId == nil {
 				doc.Feeds = append(doc.Feeds, opml.Feed{
-					Title:   feed.Title,
-					FeedUrl: feed.FeedLink,
-					SiteUrl: feed.Link,
+					Title:       feed.Title,
+					FeedUrl:     feed.FeedLink,
+					SiteUrl:     feed.Link,
+					CustomOrder: feed.CustomOrder,
 				})
 			} else {
 				id := *feed.FolderId

--- a/src/storage/migration.go
+++ b/src/storage/migration.go
@@ -16,6 +16,7 @@ var migrations = []func(*sql.Tx) error{
 	m06_fill_missing_dates,
 	m07_add_feed_size,
 	m08_normalize_datetime,
+	m09_custom_order,
 }
 
 var maxVersion = int64(len(migrations))
@@ -292,5 +293,13 @@ func m08_normalize_datetime(tx *sql.Tx) error {
 		}
 	}
 	_, err = tx.Exec(`update items set date = strftime('%Y-%m-%d %H:%M:%f', date);`)
+	return err
+}
+
+func m09_custom_order(tx *sql.Tx) error {
+	sql := `
+		alter table feeds add column custom_order text not null default "xxxxxxxxx"
+	`
+	_, err := tx.Exec(sql)
 	return err
 }


### PR DESCRIPTION
Multiple layers (OPML import/export, storage) got awareness of "custom order". We start by

This feature is not very polished, it needs you to reimport your feeds, and you probably want to mark everything read right afterwards, unless you want _old_ (and _many_) posts from your prioritized feeds to show up.

Regarding the very intrusive implementation, quoting a comment:

>Maybe a smarter & smaller thing would be: create a separate table with
>feed-url, custom-order columns, join them in this query only